### PR TITLE
[R4R]resolve internal audit comments

### DIFF
--- a/test/TestWallet.js
+++ b/test/TestWallet.js
@@ -159,6 +159,23 @@ contract('Operator Wallet: Owner Operation', (accounts) => {
         await wallet.withdraw(token.address, {from: owner});
         const balance = await token.balanceOf.call(owner);
         assert.ok(balance.toString() === web3.utils.toBN(1e18).toString());
+
+        try{
+            await wallet.pause({from: nonOwner});
+            assert.fail();
+        }catch(error){
+            assert.ok(error.toString().includes("OperatorWallet: caller is not the owner"));
+        }
+
+        await wallet.pause({from: owner});
+        try{
+            await wallet.withdraw(token.address, {from: owner});
+            assert.fail();
+        }catch(error){
+            assert.ok(error.toString().includes("Pausable: paused"));
+        }
+        await wallet.unpause({from: owner});
+        await wallet.withdraw(token.address, {from: owner});
     });
 });
 
@@ -173,7 +190,7 @@ contract('Operator Wallet:  Operator and burn', (accounts) => {
             await wallet.mint(token.address, wallet.address, web3.utils.toBN(1e18), {from: nonOperator});
             assert.fail();
         }catch(error){
-            assert.ok(error.toString().includes("OperatorWallet: caller is not the operator"));
+            assert.ok(error.toString().includes("OperatorWallet: caller is not operator or owner"));
         }
         try{
             await wallet.mint(token.address, accounts[6], web3.utils.toBN(1e18), {from: operator});
@@ -200,7 +217,7 @@ contract('Operator Wallet:  Operator and burn', (accounts) => {
             await wallet.transfer(token.address, accounts[2], web3.utils.toBN(1e17), {from: nonOperator});
             assert.fail();
         }catch(error){
-            assert.ok(error.toString().includes("OperatorWallet: caller is not the operator"));
+            assert.ok(error.toString().includes("OperatorWallet: caller is not operator or owner"));
         }
         try{
             await wallet.transfer(token.address, accounts[3], web3.utils.toBN(1e17), {from: operator});


### PR DESCRIPTION
Resolve BSC-001, BSC-002, BSC-004.

While for BSC-003:
If funds are stuck in burn wallets, we just burn them and use the operator wallet to mint. The owner of the burn wallet is not a hardware wallet, we don't want to grant it access to withdraw funds. Even if accidents happens and we want to withdraw funds, we can upgrade the implementation of burn wallet.

Detailed report:
[BSC Contract Wallet PR - Audit.pdf](https://github.com/binance-chain/wallet-contract/files/8012088/BSC.Contract.Wallet.PR.-.Audit.pdf)
